### PR TITLE
Install uwsgitop and fine tune uwsgi configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ cryptography==43.0.3
 Werkzeug==3.0.4
 # To fix "oscrypto.errors.LibraryNotFoundError: Error detecting the version of libcrypto" https://github.com/wbond/oscrypto/issues/78
 git+https://github.com/wbond/oscrypto.git@d5f3437
+uwsgitop==0.12

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -29,3 +29,43 @@ endif =
     
 callable = app
 wsgi = app
+
+# Better startup/shutdown in docker:
+die-on-term = true
+lazy-apps = false
+need-app = true
+no-defer-accept = true
+
+http-timeout = 300
+
+# This option tells uWSGI to fail to start if any parameter in the configuration file isn’t explicitly understood by uWSGI
+strict = true
+
+# Respawn processes taking more than 5 minutes and 5 seconds, same default value of nginx client timeout
+harakiri = 305
+
+# Enable Stat server with http
+stats-http = true
+
+# Config Stat Server on specific port
+stats = :1717
+
+# Restart workers after this many requests
+max-requests = 500
+
+# Add (worker_id * delta) to the max_requests value of each worker
+# to prevent all to many workers to restart at the same time
+# NEED a new release of uwsgi
+# max-requests-delta = 10
+
+# Restart workers after this many seconds, 86400 == 1 day
+max-worker-lifetime = 86400
+
+# Add (worker_id * delta) to the max-worker-lifetime value of each worker
+# to prevent all to many workers to restart at the same time
+max-worker-lifetime-delta = 15
+
+# How long to wait before forcefully killing workers
+# Set the maximum time (in seconds) a worker can take to reload/shutdown
+# (default is 60)
+worker-reload-mercy = 60


### PR DESCRIPTION
To know the status of the current uWSGI workers is more easy to install uwsgitop package.
So we can run a top like view.

The extra configs for uWSGI:
Kill requests that take too long,
restart the worker after some number of requests,
restart workers after 1 day.
This is the same approach that we have been using for LMS.

https://github.com/fccn/nau-technical/issues/687